### PR TITLE
fix: properly map config.yaml to HealthCheckConfig in smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -57,11 +57,28 @@ jobs:
           const results = [];
 
           // Run health checks for all configured services
-          for (const service of config.pings) {
+          for (const ping of config.pings) {
             try {
-              const result = await performHealthCheck(service);
+              // Map config.yaml structure to HealthCheckConfig
+              // This matches the mapping in src/index.ts
+              const healthCheckConfig = {
+                serviceName: ping.name,
+                method: ping.method,
+                url: ping.resource,
+                timeout: (ping.timeout ?? config.settings?.timeout ?? 5) * 1000,
+                warningThreshold: (ping.warning_threshold ?? config.settings?.warning_threshold ?? 2) * 1000,
+                maxRetries: config.settings?.max_retries ?? 3,
+                expectedStatus: ping.expected.status,
+                expectedText: ping.expected.text,
+                expectedHeaders: ping.expected.headers,
+                payload: ping.payload,
+                headers: ping.headers,
+                customHeaders: ping.headers?.reduce((acc, h) => ({ ...acc, [h.name]: h.value }), {})
+              };
+
+              const result = await performHealthCheck(healthCheckConfig);
               results.push({
-                serviceName: service.name,
+                serviceName: ping.name,
                 status: result.status,
                 latency_ms: result.latency_ms,
                 http_status_code: result.http_status_code,
@@ -69,7 +86,7 @@ jobs:
               });
             } catch (error) {
               results.push({
-                serviceName: service.name,
+                serviceName: ping.name,
                 status: 'FAIL',
                 latency_ms: 0,
                 http_status_code: 0,


### PR DESCRIPTION
## Summary

Fixes #9 - Smoke test commenter incorrectly reporting all services as failed

## Problem

The smoke test workflow was passing the raw `config.yaml` service object directly to `performHealthCheck()`, which expects a `HealthCheckConfig` with a `url` property. However, `config.yaml` uses `resource` as the property name.

This resulted in all health checks failing with **"Invalid URL format: undefined"** because `config.url` was undefined, leading to misleading PR comments showing "4 of 4 services (100%) failed health checks" with the scary warning banner.

## Solution

Map the `config.yaml` structure to `HealthCheckConfig` format before calling `performHealthCheck()`:

- Map `ping.resource` → `healthCheckConfig.url`
- Map all other properties to match HealthCheckConfig interface
- Convert timeout and warningThreshold from seconds to milliseconds
- Match the mapping logic already used in `src/index.ts`

## Changes

**Modified:**
- `.github/workflows/smoke-test.yml` - Added proper config mapping in "Run smoke test health checks" step

## Testing

Ran the smoke test logic locally with the fix:

**Before:**
- All 4 services: FAIL with "Invalid URL format: undefined"
- 100% failure rate triggering warning banner

**After:**
- 2 services: PASS (example, example head)
- 2 services: FAIL (example three, example five) with actual validation errors
- 50% failure rate (no warning banner)
- Accurate error messages showing real issues

## Result

- ✅ Health checks now run correctly and report actual service status
- ✅ Smoke test comments show accurate pass/fail results
- ✅ No more false "Widespread Failures Detected" warnings
- ✅ Error messages show actual validation failures, not undefined errors

## CI Status

Waiting for smoke test to run on this PR to validate the fix...

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)