### PR TITLE
feat: cache Playwright browsers in CI to speed up builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,31 @@ jobs:
         run: pnpm run test:unit
         continue-on-error: false
 
+      # Cache Playwright browsers to speed up CI builds (issue #33)
+      # Cache key is based on Playwright version from package.json for proper invalidation
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: |
+          PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package.json').devDependencies['@playwright/test'])")
+          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+          echo "Playwright version: $PLAYWRIGHT_VERSION"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      # Install browsers only if cache miss; always install OS dependencies
       - name: Install Playwright browsers
         run: pnpx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Install Playwright OS dependencies
+        run: pnpx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Generate test health data
         run: timeout 90 pnpm run check-once || true


### PR DESCRIPTION
## Summary

This PR implements Playwright browser caching in the GitHub Actions test workflow to significantly reduce CI build times.

## Changes

- Added browser binary caching to `.github/workflows/test.yml`
- Cache key uses Playwright version from `package.json` for proper invalidation
- Conditional installation: browsers only installed on cache miss
- OS dependencies always installed (even on cache hit)

## Implementation Details

**Cache Strategy:**
- Caches `~/.cache/ms-playwright` directory (Linux runner)
- Cache key: `${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}`
- Version extracted from `package.json` devDependencies

**Performance Impact:**
- Expected reduction: ~40 seconds per CI run
- Based on research showing builds reducing from 1m 43s to 45s + ~17s cache overhead
- Cache benefits compound across multiple CI runs

**Research Sources:**
- Playwright community best practices
- GitHub Actions cache documentation
- Multiple community implementations and benchmarks

## Testing

- YAML syntax validated locally
- Workflow structure follows GitHub Actions best practices
- Implementation matches proven patterns from Playwright community

## Fixes

Closes #33

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)